### PR TITLE
Allocation optimisations & Clippy cleanup

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4724,13 +4724,17 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let attestation_packing_timer =
             metrics::start_timer(&metrics::BLOCK_PRODUCTION_ATTESTATION_TIMES);
 
-        let mut prev_filter_cache = HashMap::new();
+        let prev_chain = self.clone();
+        let prev_filter_cache_lock = Mutex::new(HashMap::new());
         let prev_attestation_filter = |att: &AttestationRef<T::EthSpec>| {
-            self.filter_op_pool_attestation(&mut prev_filter_cache, att, &state)
+            let mut prev_filter_cache = prev_filter_cache_lock.lock();
+            prev_chain.filter_op_pool_attestation(&mut prev_filter_cache, att, &state)
         };
-        let mut curr_filter_cache = HashMap::new();
+        let curr_chain = self.clone();
+        let curr_filter_cache_lock = Mutex::new(HashMap::new());
         let curr_attestation_filter = |att: &AttestationRef<T::EthSpec>| {
-            self.filter_op_pool_attestation(&mut curr_filter_cache, att, &state)
+            let mut curr_filter_cache = curr_filter_cache_lock.lock();
+            curr_chain.filter_op_pool_attestation(&mut curr_filter_cache, att, &state)
         };
 
         let mut attestations = self

--- a/beacon_node/operation_pool/src/attestation.rs
+++ b/beacon_node/operation_pool/src/attestation.rs
@@ -193,6 +193,7 @@ pub fn earliest_attestation_validators<T: EthSpec>(
     } else if attestation.checkpoint.target_epoch == state.previous_epoch() {
         &base_state.previous_epoch_attestations
     } else {
+        #[allow(clippy::unwrap_used)]
         return BitList::with_capacity(0).unwrap();
     };
 

--- a/beacon_node/operation_pool/src/attestation_storage.rs
+++ b/beacon_node/operation_pool/src/attestation_storage.rs
@@ -163,7 +163,7 @@ impl<T: EthSpec> AttestationMap<T> {
             attestation_map
                 .unaggregate_attestations
                 .entry(data)
-                .or_insert_with(Vec::new)
+                .or_default()
         };
         let mut observed = false;
         for existing_attestation in attestations.iter_mut() {

--- a/beacon_node/operation_pool/src/max_cover.rs
+++ b/beacon_node/operation_pool/src/max_cover.rs
@@ -68,7 +68,7 @@ where
         .filter(|x| x.item.score() != 0)
         .map(|val| (val.item.key(), val))
         .fold(HashMap::new(), |mut acc, (key, val)| {
-            acc.entry(key).or_insert(Vec::new()).push(val);
+            acc.entry(key).or_default().push(val);
             acc
         });
 
@@ -98,7 +98,7 @@ where
 
         // Update the covering sets of the other items, for the inclusion of the selected item.
         // Items covered by the selected item can't be re-covered.
-        all_items.get_mut(&best_key).map(|items| {
+        if let Some(items) = all_items.get_mut(&best_key) {
             items
                 .iter_mut()
                 .filter(|x| x.available && x.item.score() != 0)
@@ -106,7 +106,7 @@ where
                     x.item
                         .update_covering_set(best_item.intermediate(), best_item.covering_set())
                 });
-        });
+        }
 
         result.push(best_item);
     }
@@ -165,7 +165,7 @@ mod test {
             self.len()
         }
 
-        fn key(&self) -> () {}
+        fn key(&self) {}
     }
 
     fn example_system() -> Vec<HashSet<usize>> {


### PR DESCRIPTION
## Proposed Changes

I started trying to get the Clippy lints to pass and then I got a bit carried away. I ended up removing all indexing (which could panic) and unwraps. And I found a way to get rid of some intermediate `collect`s by messing with the validity filters (making them safe to share between threads).

I also reversed the polarity of the `hash_set_filter` predicate, so that it matches `Iterator::filter`.
