### PR TITLE
Fix compute_neighbourhoods

### DIFF
--- a/beacon_node/operation_pool/src/attestation_storage.rs
+++ b/beacon_node/operation_pool/src/attestation_storage.rs
@@ -244,17 +244,12 @@ impl<T: EthSpec> AttestationDataMap<T> {
 
     pub fn stats(&self) -> AttestationStats {
         let mut stats = AttestationStats::default();
-        let mut max_aggregates_per_data = 0;
 
-        for (_, aggregates) in self.aggregate_attestations.iter() {
+        for aggregates in self.aggregate_attestations.values() {
             stats.num_attestations += aggregates.len();
             stats.num_attestation_data += 1;
             stats.max_aggregates_per_data =
                 std::cmp::max(stats.max_aggregates_per_data, aggregates.len());
-
-            if aggregates.len() > max_aggregates_per_data {
-                max_aggregates_per_data = aggregates.len();
-            }
         }
 
         for (data, unaggregates) in self.unaggregate_attestations.iter() {

--- a/beacon_node/operation_pool/src/bron_kerbosch.rs
+++ b/beacon_node/operation_pool/src/bron_kerbosch.rs
@@ -57,7 +57,7 @@ fn compute_neighbourhoods<T, F: Fn(&T, &T) -> bool>(
     let mut neighbourhoods = vec![];
     neighbourhoods.resize_with(vertices.len(), Vec::new);
     for (i, vi) in vertices.get(0..vertices.len() - 1)?.iter().enumerate() {
-        for (j, vj) in vertices.get(i + 1..vertices.len())?.iter().enumerate() {
+        for (j, vj) in vertices.iter().enumerate().skip(i + 1) {
             if is_compatible(vi, vj) {
                 neighbourhoods.get_mut(i)?.push(j);
                 neighbourhoods.get_mut(j)?.push(i);

--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -1309,20 +1309,22 @@ mod release_tests {
             }
         }
 
-        let mut num_valid = 0;
+        let num_valid = AtomicUsize::new(0);
         let (_, curr) = CheckpointKey::keys_for_state(&state);
         let all_attestations = op_pool.attestations.read();
 
         complete_state_advance(&mut state, None, Slot::new(1), spec).unwrap();
-        let clique_attestations = op_pool.get_clique_aggregate_attestations_for_epoch(
-            &curr,
-            &all_attestations,
-            &state,
-            |_| true,
-            &mut num_valid,
-            32,
-            spec,
-        );
+        let clique_attestations = op_pool
+            .get_clique_aggregate_attestations_for_epoch(
+                &curr,
+                &all_attestations,
+                &state,
+                |_| true,
+                &num_valid,
+                32,
+                spec,
+            )
+            .unwrap();
         let best_attestations = op_pool
             .get_attestations(&state, |_| true, |_| true, 32, spec)
             .unwrap();


### PR DESCRIPTION
In my previous PR I messed up the implementation of `compute_neighbourhoods` which caused the tests to fail! The `j` indices were beginning from 0, rather than from `i + 1` as they should.

I also simplified `stats` a little and plumbed the AtomicUsize into the tests.